### PR TITLE
Change credited name and email address in comment

### DIFF
--- a/scripts/ssl-heartbleed.nse
+++ b/scripts/ssl-heartbleed.nse
@@ -11,7 +11,7 @@ assert(have_tls, "This script requires the tls.lua library from https://nmap.org
 
 description = [[
 Detects whether a server is vulnerable to the OpenSSL Heartbleed bug (CVE-2014-0160).
-The code is based on the Python script ssltest.py authored by Jared Stafford (jspenguin@jspenguin.org)
+The code is based on the Python script ssltest.py authored by Katie Stafford (katie@ktpanda.org)
 ]]
 
 ---


### PR DESCRIPTION
I am the author of the original ssltest.py and I have changed my name and email address. This can be verified by noting that https://jspenguin.org now redirects to ktpanda.org. I can also verify this by email since I am still able to receive mail sent to the original address.